### PR TITLE
Retrieve User Detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Data Diagram for the database
     FOREIGN KEY (username) REFERENCES user(username) ON DELETE CASCADE ON UPDATE CASCADE,
     email VARCHAR(255) NOT NULL,
     primary_addr BOOLEAN NOT NULL,
-    verified BOOLEAN NOT NULL
+    INDEX index_primary_addr(primary_addr),
+    verified BOOLEAN NOT NULL,
+    INDEX index_verified(verified)
   ) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
   ```
 
@@ -75,7 +77,8 @@ Data Diagram for the database
     id VARCHAR(44) NOT NULL PRIMARY KEY,
     email_id INT(11) NOT NULL,
     FOREIGN KEY (email_id) REFERENCES user_email(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    expires TIMESTAMP NOT NULL
+    expires TIMESTAMP NOT NULL,
+    INDEX index_expires(expires)
   ) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
   ```
 

--- a/src/ServerConfigExample.ts
+++ b/src/ServerConfigExample.ts
@@ -36,7 +36,7 @@ export default class ServerConfig extends ServerConfigTemplate {
         db: 15,
       },
       expressPort: 3000,
-      jwtKeys: {secretKey: 'keySecret', refreshKey: 'keySecret'},
+      jwtKeys: {secretKey: 'keySecret', refreshKey: 'keySecretRefresh'},
     };
     super(config);
   }

--- a/src/datatypes/user/User.ts
+++ b/src/datatypes/user/User.ts
@@ -127,6 +127,8 @@ export default class User implements LoginCredentials {
     if (queryResult.length !== 1) {
       throw new NotFoundError();
     }
+
+    queryResult[0].admin = queryResult[0].admin === 1;
     const user = new User(
       queryResult[0].username,
       queryResult[0].password,

--- a/src/datatypes/user/UserDetailResponse.ts
+++ b/src/datatypes/user/UserDetailResponse.ts
@@ -1,0 +1,159 @@
+/**
+ * Define type and Read Methods (DB) for the object contains User's detail
+ * that will be return as a response of GET /user/{username}
+ *
+ * password, memberSince, user status and admin status should not be included at all time.
+ * phoneNumber is retrieved only when admin account or account owner calls the method.
+ * For admin account and account owner,
+ * list of all email addresses associated with the account will be returned,
+ * while the others will get verified primary email account only.
+ *
+ * @author Hyecheol (Jerry) Jang
+ */
+
+import * as mariadb from 'mariadb';
+import User from './User';
+import UserEmail from './UserEmail';
+import UserEmailResponse from './UserEmailResponse';
+import UserPhoneNumber from './UserPhoneNumber';
+import NotFoundError from '../../exceptions/NotFoundError';
+
+/**
+ * Class for UserDetailResponse
+ */
+export default class UserDetailResponse {
+  username: string;
+  admissionYear: number;
+  legalName: string;
+  nickname?: string;
+  email: UserEmailResponse[];
+  phoneNumber?: {countryCode: number; phoneNumber: number};
+  affiliation?: {schoolCompany: string; majorDepartment: string};
+
+  /**
+   * Constructor for UserDetailResponse with required fields
+   *
+   * @param username username associated with the target user
+   * @param admissionYear admission year of the user
+   * @param legalName legal name of the user
+   * @param email email associated with the user
+   */
+  constructor(
+    username: string,
+    admissionYear: number,
+    legalName: string,
+    email: UserEmailResponse[]
+  ) {
+    this.username = username;
+    this.admissionYear = admissionYear;
+    this.legalName = legalName;
+    this.email = email;
+  }
+
+  /**
+   * Get UserDetailResponse for non-admin/non-owner users' request
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param username username associated with the search target
+   * @return {Promise<UserDetailResponse>}
+   *   UserDetailResponse for non-admin/non-owner users' request
+   */
+  static async read(
+    dbClient: mariadb.Pool,
+    username: string
+  ): Promise<UserDetailResponse> {
+    const queryResult = await dbClient.query(
+      String.prototype.concat(
+        'SELECT * FROM user ',
+        'LEFT JOIN user_email ',
+        'ON user.username = user_email.username',
+        'AND user_email.primary_addr = true,',
+        'AND user_email.verified = true',
+        'WHERE user.username = ?,'
+      ),
+      username
+    );
+
+    if (queryResult.length !== 1) {
+      throw new NotFoundError();
+    }
+
+    // Generate UserDetailResponse Object
+    let response: UserDetailResponse;
+    if (queryResult[0].verified === null) {
+      // Email not yet verified
+      response = new UserDetailResponse(
+        queryResult[0].username,
+        queryResult[0].admission_year,
+        queryResult[0].legal_name,
+        []
+      );
+    } else {
+      // Email verified
+      const email: UserEmailResponse = {
+        email: queryResult[0].email,
+        primaryAddr: true,
+        verified: true,
+      };
+      response = new UserDetailResponse(
+        queryResult[0].username,
+        queryResult[0].admission_year,
+        queryResult[0].legal_name,
+        [email]
+      );
+    }
+    if (queryResult[0].nickname) {
+      response.nickname = queryResult[0].nickname;
+    }
+    if (queryResult[0].major_department && queryResult[0].school_company) {
+      response.affiliation = {
+        majorDepartment: queryResult[0].major_department,
+        schoolCompany: queryResult[0].school_company,
+      };
+    }
+
+    return response;
+  }
+
+  /**
+   * Get UserDetailResponse for admin/owner users' request
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param username username associated with the search target
+   * @return {Promise<UserDetailResponse>}
+   *   UserDetailResponse for admin/owner users' request
+   */
+  static async readAdminOwner(
+    dbClient: mariadb.Pool,
+    username: string
+  ): Promise<UserDetailResponse> {
+    const queries = await Promise.all([
+      User.read(dbClient, username),
+      UserEmail.read(dbClient, username),
+      UserPhoneNumber.read(dbClient, username),
+    ]);
+
+    const response = new UserDetailResponse(
+      queries[0].username,
+      queries[0].admissionYear,
+      queries[0].legalName,
+      queries[1]
+    );
+    if (queries[0].nickname) {
+      response.nickname = queries[0].nickname;
+    }
+    if (queries[0].majorDepartment && queries[0].schoolCompany) {
+      response.affiliation = {
+        majorDepartment: queries[0].majorDepartment,
+        schoolCompany: queries[0].schoolCompany,
+      };
+    }
+    if (queries[2] !== null) {
+      response.phoneNumber = {
+        countryCode: queries[2].countryCode,
+        phoneNumber: queries[2].phoneNumber,
+      };
+    }
+    return response;
+  }
+}

--- a/src/datatypes/user/UserEmail.ts
+++ b/src/datatypes/user/UserEmail.ts
@@ -5,6 +5,7 @@
  */
 
 import * as mariadb from 'mariadb';
+import UserEmailResponse from './UserEmailResponse';
 
 /**
  * Class for UserEmail
@@ -53,5 +54,32 @@ export default class UserEmail {
       ),
       [email.username, email.email, email.primaryAddr, email.verified]
     );
+  }
+
+  /**
+   * Retrieve user_email entry
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param username username associated with the user_email entries
+   * @return {Promise<UserEmailResponse[]>} Array of UserEmailResponse with email addresses associated with the user
+   */
+  static async read(
+    dbClient: mariadb.Pool,
+    username: string
+  ): Promise<UserEmailResponse[]> {
+    const queryResult = await dbClient.query(
+      'SELECT * FROM user_email WHERE username = ?',
+      username
+    );
+
+    const response: UserEmailResponse[] = [];
+    for (const i of queryResult) {
+      response.push({
+        email: i.email,
+        primaryAddr: i.primary_addr,
+        verified: i.verified,
+      });
+    }
+    return response;
   }
 }

--- a/src/datatypes/user/UserEmail.ts
+++ b/src/datatypes/user/UserEmail.ts
@@ -74,6 +74,9 @@ export default class UserEmail {
 
     const response: UserEmailResponse[] = [];
     for (const i of queryResult) {
+      i.primary_addr = i.primary_addr === 1;
+      i.verified = i.verified === 1;
+
       response.push({
         email: i.email,
         primaryAddr: i.primary_addr,

--- a/src/datatypes/user/UserEmailResponse.ts
+++ b/src/datatypes/user/UserEmailResponse.ts
@@ -1,0 +1,17 @@
+/**
+ * Define type for the object contains UserEmail Information
+ *
+ * When look for email address information,
+ * users do not need to get username information
+ *
+ * @author Hyecheol (Jerry) Jang
+ */
+
+/**
+ * Interface for UserEmailResponse
+ */
+export default interface UserEmailResponse {
+  email: string;
+  primaryAddr: boolean;
+  verified: boolean;
+}

--- a/src/datatypes/user/UserPhoneNumber.ts
+++ b/src/datatypes/user/UserPhoneNumber.ts
@@ -45,4 +45,29 @@ export default class UserPhoneNumber {
       [phoneNumber.username, phoneNumber.countryCode, phoneNumber.phoneNumber]
     );
   }
+
+  /**
+   * Retrieve an existing user_phone_number entry associated with given username
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param username username associated with the user_phone_number entry
+   */
+  static async read(
+    dbClient: mariadb.Pool,
+    username: string
+  ): Promise<UserPhoneNumber | null> {
+    const queryResult = await dbClient.query(
+      'SELECT * FROM user_phone_number WHERE username = ?',
+      username
+    );
+    if (queryResult.length !== 0) {
+      return {
+        username: queryResult[0].username,
+        countryCode: queryResult[0].country_code,
+        phoneNumber: queryResult[0].phone_number,
+      };
+    } else {
+      return null;
+    }
+  }
 }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -15,6 +15,8 @@ import User from '../datatypes/user/User';
 import UserEmail from '../datatypes/user/UserEmail';
 import UserEmailVerifyTicket from '../datatypes/user/UserEmailVerifyTicket';
 import UserPhoneNumber from '../datatypes/user/UserPhoneNumber';
+import accessTokenVerify from '../functions/JWT/accessTokenVerify';
+import UserDetailResponse from '../datatypes/user/UserDetailResponse';
 
 // Path: /user
 const userRouter = express.Router();
@@ -108,6 +110,31 @@ userRouter.post('/', async (req, res, next) => {
 
     // Response
     res.status(200).json({username: user.username});
+  } catch (e) {
+    next(e);
+  }
+});
+
+// GET /user/{username}
+userRouter.get(':username', async (req, res, next) => {
+  try {
+    const dbClient = req.app.locals.dbClient;
+    const username = req.params.username;
+
+    // Check Access Token
+    const tokenContent = accessTokenVerify(req, req.app.get('jwtAccessKey'));
+
+    let response: UserDetailResponse;
+    if (tokenContent.admin === true || tokenContent.username === username) {
+      // Admin/Owner Request
+      response = await UserDetailResponse.readAdminOwner(dbClient, username);
+    } else {
+      // Non-admin request
+      response = await UserDetailResponse.read(dbClient, username);
+    }
+
+    // Response
+    res.status(200).json(response);
   } catch (e) {
     next(e);
   }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -116,7 +116,7 @@ userRouter.post('/', async (req, res, next) => {
 });
 
 // GET /user/{username}
-userRouter.get(':username', async (req, res, next) => {
+userRouter.get('/:username', async (req, res, next) => {
   try {
     const dbClient = req.app.locals.dbClient;
     const username = req.params.username;

--- a/test/TestConfig.ts
+++ b/test/TestConfig.ts
@@ -43,7 +43,7 @@ export default class TestConfig extends ServerConfigTemplate {
         prefix: `${redisIdentifier}_`,
       },
       expressPort: 3000,
-      jwtKeys: {secretKey: 'keySecret', refreshKey: 'keySecret'},
+      jwtKeys: {secretKey: 'keySecret', refreshKey: 'keySecretRefresh'},
     };
     super(config);
     this.redisIdentifier = redisIdentifier;

--- a/test/TestEnv.ts
+++ b/test/TestEnv.ts
@@ -146,7 +146,7 @@ export default class TestEnv {
         'major_department VARCHAR(255) NULL DEFAULT NULL,',
         'status VARCHAR(10) NOT NULL,',
         'admin BOOLEAN NOT NULL',
-        ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ENGINE=MEMORY;'
+        ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;'
       )
     );
     await Promise.all([
@@ -159,8 +159,10 @@ export default class TestEnv {
           'FOREIGN KEY (username) REFERENCES user(username) ON DELETE CASCADE ON UPDATE CASCADE,',
           'email VARCHAR(255) NOT NULL,',
           'primary_addr BOOLEAN NOT NULL,',
-          'verified BOOLEAN NOT NULL',
-          ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ENGINE=MEMORY;'
+          'INDEX index_primary_addr(primary_addr),',
+          'verified BOOLEAN NOT NULL,',
+          'INDEX index_verified(verified)',
+          ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;'
         )
       ),
       // user_phone_number
@@ -171,7 +173,7 @@ export default class TestEnv {
           'FOREIGN KEY (username) REFERENCES user(username) ON DELETE CASCADE ON UPDATE CASCADE,',
           'country_code TINYINT(3) NOT NULL,',
           'phone_number BIGINT(15) NOT NULL',
-          ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ENGINE=MEMORY;'
+          ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;'
         )
       ),
     ]);
@@ -182,8 +184,9 @@ export default class TestEnv {
         'id VARCHAR(44) NOT NULL PRIMARY KEY,',
         'email_id INT(11) NOT NULL,',
         'FOREIGN KEY (email_id) REFERENCES user_email(id) ON DELETE CASCADE ON UPDATE CASCADE,',
-        'expires TIMESTAMP NOT NULL',
-        ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ENGINE=MEMORY;'
+        'expires TIMESTAMP NOT NULL,',
+        'INDEX index_expires(expires)',
+        ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;'
       )
     );
 

--- a/test/testcases/auth/get.renew.test.ts
+++ b/test/testcases/auth/get.renew.test.ts
@@ -154,7 +154,7 @@ describe('GET /auth/renew - renew access/refresh token', () => {
     expect(cookie[0]).toBe('X-REFRESH-TOKEN'); // Check for Refresh Token Name
     let tokenPayload = jwt.verify(
       cookie[1],
-      testEnv.testConfig.jwt.secretKey,
+      testEnv.testConfig.jwt.refreshKey,
       jwtOption
     ) as AuthToken; // Check for AccessToken contents
     expect(tokenPayload.username).toBe('testuser1');

--- a/test/testcases/user/get.{username}.test.ts
+++ b/test/testcases/user/get.{username}.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Jest unit test for GET /user/{username} method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import * as jwt from 'jsonwebtoken';
+// eslint-disable-next-line node/no-unpublished-import
+import MockDate from 'mockdate';
+import TestEnv from '../../TestEnv';
+
+describe('GET /user/{username} - Retrieve user detail', () => {
+  let testEnv: TestEnv;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup TestEnv
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    const resourceList = ['USER'];
+    await testEnv.start(resourceList);
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success - Owner', async () => {
+    // Login with testuser1
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    let accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+    // Retrieve user information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/testuser1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser1');
+    expect(response.body.admissionYear).toBe(13);
+    expect(response.body.legalName).toBe('홍길동');
+    expect(response.body.nickname).toBe(undefined);
+    expect(response.body.email.length).toBe(1);
+    expect(response.body.email[0].email).toBe('testuser1@gmail.com');
+    expect(response.body.email[0].primaryAddr).toBe(true);
+    expect(response.body.email[0].verified).toBe(false);
+    expect(response.body.phoneNumber).toBe(undefined);
+    expect(response.body.affiliation).toBe(undefined);
+
+    // Login with testuser2
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Retrieve user information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/testuser2')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser2');
+    expect(response.body.admissionYear).toBe(1);
+    expect(response.body.legalName).toBe('김철수');
+    expect(response.body.nickname).toBe('Charles Kim');
+    expect(response.body.email.length).toBe(2);
+    for (const obj of response.body.email) {
+      switch (obj.email) {
+        case 'charles@gmail.com':
+          expect(obj.primaryAddr).toBe(true);
+          expect(obj.verified).toBe(true);
+          break;
+        case 'charles@hotmail.com':
+          expect(obj.primaryAddr).toBe(false);
+          expect(obj.verified).toBe(false);
+          break;
+        default:
+          fail();
+      }
+    }
+    expect(response.body.phoneNumber.countryCode).toBe(82);
+    expect(response.body.phoneNumber.phoneNumber).toBe(1012345678);
+    expect(response.body.affiliation).toBe(undefined);
+
+    // Login with admin1
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Retrieve user information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/admin1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('admin1');
+    expect(response.body.admissionYear).toBe(6);
+    expect(response.body.legalName).toBe('최영재');
+    expect(response.body.nickname).toBe('나똑똑');
+    expect(response.body.email.length).toBe(3);
+    for (const obj of response.body.email) {
+      switch (obj.email) {
+        case 'charles@hotmail.com':
+          expect(obj.primaryAddr).toBe(true);
+          expect(obj.verified).toBe(true);
+          break;
+        case 'charles.temp@hotmail.com':
+          expect(obj.primaryAddr).toBe(false);
+          expect(obj.verified).toBe(true);
+          break;
+        case 'charles.a2@hotmail.com':
+          expect(obj.primaryAddr).toBe(false);
+          expect(obj.verified).toBe(false);
+          break;
+        default:
+          fail();
+      }
+    }
+    expect(response.body.phoneNumber.countryCode).toBe(1);
+    expect(response.body.phoneNumber.phoneNumber).toBe(2345678901);
+    expect(response.body.affiliation).not.toBe(undefined);
+    expect(response.body.affiliation.schoolCompany).toBe(
+      'Busan Science High School'
+    );
+    expect(response.body.affiliation.majorDepartment).toBe('Student');
+  });
+
+  // Success - Admin
+  test('Success - Admin', async () => {
+    // Login with admin1
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Retrieve testuser1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/testuser1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser1');
+    expect(response.body.admissionYear).toBe(13);
+    expect(response.body.legalName).toBe('홍길동');
+    expect(response.body.nickname).toBe(undefined);
+    expect(response.body.email.length).toBe(1);
+    expect(response.body.email[0].email).toBe('testuser1@gmail.com');
+    expect(response.body.email[0].primaryAddr).toBe(true);
+    expect(response.body.email[0].verified).toBe(false);
+    expect(response.body.phoneNumber).toBe(undefined);
+    expect(response.body.affiliation).toBe(undefined);
+
+    // Retrieve testuser2 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/testuser2')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser2');
+    expect(response.body.admissionYear).toBe(1);
+    expect(response.body.legalName).toBe('김철수');
+    expect(response.body.nickname).toBe('Charles Kim');
+    expect(response.body.email.length).toBe(2);
+    for (const obj of response.body.email) {
+      switch (obj.email) {
+        case 'charles@gmail.com':
+          expect(obj.primaryAddr).toBe(true);
+          expect(obj.verified).toBe(true);
+          break;
+        case 'charles@hotmail.com':
+          expect(obj.primaryAddr).toBe(false);
+          expect(obj.verified).toBe(false);
+          break;
+        default:
+          fail();
+      }
+    }
+    expect(response.body.phoneNumber.countryCode).toBe(82);
+    expect(response.body.phoneNumber.phoneNumber).toBe(1012345678);
+    expect(response.body.affiliation).toBe(undefined);
+  });
+
+  test('Success - Others', async () => {
+    // testuser1 -> admin1 (Multiple verified email / phone number)
+    // Login with testuser1
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    let accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+    // Retrieve admin1 user information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/admin1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('admin1');
+    expect(response.body.admissionYear).toBe(6);
+    expect(response.body.legalName).toBe('최영재');
+    expect(response.body.nickname).toBe('나똑똑');
+    expect(response.body.email.length).toBe(1);
+    expect(response.body.email[0].email).toBe('charles@hotmail.com');
+    expect(response.body.email[0].primaryAddr).toBe(true);
+    expect(response.body.email[0].verified).toBe(true);
+    expect(response.body.phoneNumber).toBe(undefined);
+    expect(response.body.affiliation).not.toBe(undefined);
+    expect(response.body.affiliation.schoolCompany).toBe(
+      'Busan Science High School'
+    );
+    expect(response.body.affiliation.majorDepartment).toBe('Student');
+
+    // testuser1 -> testuser2 (Only one verified email)
+    // Signed in above
+    // Retrieve testuser2 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/testuser2')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser2');
+    expect(response.body.admissionYear).toBe(1);
+    expect(response.body.legalName).toBe('김철수');
+    expect(response.body.nickname).toBe('Charles Kim');
+    expect(response.body.email.length).toBe(1);
+    expect(response.body.email[0].email).toBe('charles@gmail.com');
+    expect(response.body.email[0].primaryAddr).toBe(true);
+    expect(response.body.email[0].verified).toBe(true);
+    expect(response.body.phoneNumber).toBe(undefined);
+    expect(response.body.affiliation).toBe(undefined);
+
+    // testuser2 -> testuser1 (No verified email / no phone number)
+    // Login
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Retrieve testuser1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/testuser1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.username).toBe('testuser1');
+    expect(response.body.admissionYear).toBe(13);
+    expect(response.body.legalName).toBe('홍길동');
+    expect(response.body.nickname).toBe(undefined);
+    expect(response.body.email.length).toBe(0);
+    expect(response.body.phoneNumber).toBe(undefined);
+    expect(response.body.affiliation).toBe(undefined);
+  });
+
+  test('Fail - Search for Suspended User', async () => {
+    // Admin Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    let accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+    // Retrieve suspended1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/suspended1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Suspended User');
+
+    // Other (testuser2) login
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Retrieve suspended1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/suspended1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Suspended User');
+  });
+
+  test('Fail - Search for Deleted User', async () => {
+    // Admin Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    let accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+    // Retrieve deleted1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/deleted1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // Other (testuser2) login
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Retrieve deleted1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/deleted1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+  });
+
+  test('Fail - Expired Access Token', async () => {
+    const currentDate = new Date();
+    MockDate.set(currentDate);
+
+    // Admin Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    let accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+    // Access Token Expired
+    currentDate.setMinutes(currentDate.getMinutes() + 20);
+    MockDate.set(currentDate);
+    // Retrieve deleted1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/deleted1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+
+    // Other (testuser2) login
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Access Token Expired
+    currentDate.setMinutes(currentDate.getMinutes() + 20);
+    MockDate.set(currentDate);
+    // Retrieve deleted1 information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/deleted1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+  });
+
+  test('Fail - Invalid Access Token (Not signed with proper keys)', async () => {
+    // Create AccessToken
+    const tokenContent = {
+      username: 'testuser1',
+      type: 'access',
+      status: 'unverified',
+    };
+    const accessToken = jwt.sign(
+      tokenContent,
+      testEnv.testConfig.jwt.refreshKey,
+      {algorithm: 'HS512', expiresIn: '15m'}
+    );
+
+    // Request with invalid access token
+    const response = await request(testEnv.expressServer.app)
+      .get('/user/testuser1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+  });
+
+  test('Fail - Token type is not "access"', async () => {
+    // Create AccessToken
+    const tokenContent = {
+      username: 'testuser1',
+      type: 'unknown',
+      status: 'unverified',
+    };
+    const accessToken = jwt.sign(
+      tokenContent,
+      testEnv.testConfig.jwt.secretKey,
+      {algorithm: 'HS512', expiresIn: '15m'}
+    );
+
+    // Request with invalid access token
+    const response = await request(testEnv.expressServer.app)
+      .get('/user/testuser1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+  });
+
+  test('Fail - Request without access token', async () => {
+    // Admin Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    // Retrieve testuser1 information without accessToken
+    response = await request(testEnv.expressServer.app).get('/user/testuser1');
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+
+    // Other (testuser2) login
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    // Retrieve deleted1 information without accessToken
+    response = await request(testEnv.expressServer.app).get('/user/deleted1');
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+  });
+
+  test('Fail - Username not found', async () => {
+    // Admin Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'admin1', password: 'rootPW12!@'});
+    expect(response.status).toBe(200);
+    let accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+    // Retrieve not existing user's information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/notexist')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // Other (testuser2) login
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+    // Retrieve not existing user's information
+    response = await request(testEnv.expressServer.app)
+      .get('/user/notexist')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+  });
+});


### PR DESCRIPTION
Retrieving user's detail information.
- Username is provided as a path parameter
- When owner of account or admin call the function: get all detailed information (admissionYear, legalName, nickname, all email on file, phoneNumber, and affiliation) about the user except for current password.
- When other users call the function: Get limited information regarding the account (admissionYear, legalName, nickName, verified primary email account, and affiliation).

Fixed minor problems
- `src/datatypes/user/User.ts` return `admin` value as 1 or 0 (numeric). Changed to boolean.

Server Configuration changed
- Changed DB Table (Added Index to enhance search speed)
- Server configuration changed (example of secret key)
  - Modified Test codes